### PR TITLE
Do not consider bridge methods

### DIFF
--- a/ch.vorburger.xtendbeans/src/main/java/ch/vorburger/xtendbeans/ReflectUtils.xtend
+++ b/ch.vorburger.xtendbeans/src/main/java/ch/vorburger/xtendbeans/ReflectUtils.xtend
@@ -40,6 +40,7 @@ package class ReflectUtils {
                  && !Modifier.isStatic(method.getModifiers())
                  && !Modifier.isAbstract(method.getModifiers())
                  && !isObjectMethod(method)
+                 && !method.isBridge()
                 ) {
                     // Check if it looks like a setter of some sort
                     if (method.parameterTypes.length == 1) {


### PR DESCRIPTION
A simple construct, where a getter method is specified by a generic
interface fails to work.

interface FooSupplier<T> {
  T getFoo();
}

class FooString implements FooSupplier<String> {
  FooString(String foo) {
    // ..
  }

  @Override
  public String getFoo() {
    // ..
  }
}

This fails because the code gets confused by the synthetic bridge
method which gets to satisfy FooSupplier erasure. Fix this by ignoring
all bridges.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>